### PR TITLE
Fixed image preview sizing

### DIFF
--- a/src/app/avisos/aviso-form.component.html
+++ b/src/app/avisos/aviso-form.component.html
@@ -13,7 +13,11 @@
     <div *ngIf="form.get('descripcion')?.invalid && form.get('descripcion')?.touched">La descripción debe tener mínimo 20 caracteres</div>
 
     <ion-button type="button" (click)="tomarFoto()">Tomar Foto</ion-button>
-    <ion-img *ngIf="form.value.foto" [src]="form.value.foto"></ion-img>
+    <ion-img
+      *ngIf="form.value.foto"
+      [src]="form.value.foto"
+      class="foto-preview"
+    ></ion-img>
 
     <ion-button type="submit" expand="full" [disabled]="form.invalid">Guardar</ion-button>
   </form>

--- a/src/app/avisos/aviso-form.component.scss
+++ b/src/app/avisos/aviso-form.component.scss
@@ -1,0 +1,7 @@
+ion-img.foto-preview {
+  width: 200px;
+  height: 200px;
+  object-fit: cover;
+  display: block;
+  margin: 16px auto;
+}

--- a/src/app/avisos/aviso-item.component.html
+++ b/src/app/avisos/aviso-item.component.html
@@ -1,5 +1,10 @@
 <ion-item>
-  <ion-img *ngIf="aviso.foto" [src]="aviso.foto" slot="start"></ion-img>
+  <ion-img
+    *ngIf="aviso.foto"
+    [src]="aviso.foto"
+    slot="start"
+    class="foto-mini"
+  ></ion-img>
   <ion-label>
     <h2>{{ aviso.titulo }}</h2>
     <p>{{ aviso.fecha | fecha }}</p>

--- a/src/app/avisos/aviso-item.component.scss
+++ b/src/app/avisos/aviso-item.component.scss
@@ -1,0 +1,5 @@
+ion-img.foto-mini {
+  width: 64px;
+  height: 64px;
+  object-fit: cover;
+}


### PR DESCRIPTION
## Summary
- resize preview image in new notice form
- show smaller thumbnails in the notice list

## Testing
- `npx ng test --watch=false --browsers=ChromeHeadless` *(fails: ChromeHeadless requires chromium snap)*

------
https://chatgpt.com/codex/tasks/task_e_6878f62fc0788330b4c05a8486568881