### PR TITLE
Fix focus and PWA camera

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "@capacitor/keyboard": "latest",
         "@capacitor/status-bar": "latest",
         "@ionic/angular": "^8.0.0",
+        "@ionic/pwa-elements": "^3.3.0",
         "ionicons": "^7.0.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
@@ -4054,6 +4055,16 @@
         "@stencil/core": "4.33.1",
         "ionicons": "^7.2.2",
         "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@ionic/pwa-elements": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@ionic/pwa-elements/-/pwa-elements-3.3.0.tgz",
+      "integrity": "sha512-vbykpxd2nGRlA67AnqDwsiVf8PUmInLyi6lQdnPDjeiML1WZa0CPe6r632nGDV9PTi+sWNde9Xexg9SD6Pwyqw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=8.0.0"
       }
     },
     "node_modules/@ionic/utils-array": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@capacitor/keyboard": "latest",
     "@capacitor/status-bar": "latest",
     "@ionic/angular": "^8.0.0",
+    "@ionic/pwa-elements": "^3.3.0",
     "ionicons": "^7.0.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",

--- a/src/app/avisos/avisos-list.component.ts
+++ b/src/app/avisos/avisos-list.component.ts
@@ -37,6 +37,7 @@ export class AvisosListComponent implements OnInit {
   }
 
   nuevo() {
+    (document.activeElement as HTMLElement | null)?.blur();
     this.router.navigate(['/avisos/nuevo']);
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,14 +1,16 @@
 import { bootstrapApplication } from '@angular/platform-browser';
 import { RouteReuseStrategy, provideRouter, withPreloading, PreloadAllModules } from '@angular/router';
 import { IonicRouteStrategy, provideIonicAngular } from '@ionic/angular/standalone';
-import { defineCustomElements } from 'jeep-sqlite/loader';
+import { defineCustomElements as jeepDefineCustomElements } from 'jeep-sqlite/loader';
+import { defineCustomElements as pwaDefineCustomElements } from '@ionic/pwa-elements/loader';
 import { addIcons } from 'ionicons';
 import { add as addIcon } from 'ionicons/icons';
 
 import { routes } from './app/app.routes';
 import { AppComponent } from './app/app.component';
 
-defineCustomElements(window);
+jeepDefineCustomElements(window);
+pwaDefineCustomElements(window);
 addIcons({ add: addIcon });
 
 bootstrapApplication(AppComponent, {


### PR DESCRIPTION
## Summary
- use `@ionic/pwa-elements` for camera modal
- blur active element when navigating to new aviso

## Testing
- `npm test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_6878fbabc6908330bad51faf089e3420